### PR TITLE
Remove duplicate SessionMiddleware entry

### DIFF
--- a/framework/settings.py
+++ b/framework/settings.py
@@ -49,7 +49,6 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     # 'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
## Summary
- avoid duplicate session middleware execution by keeping only one SessionMiddleware entry

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_689396357cd48323aa9fbd5f3447d9be