### PR TITLE
Add LLM provider stubs

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,1 @@
+"""LLM provider utilities."""

--- a/llm/providers/__init__.py
+++ b/llm/providers/__init__.py
@@ -1,0 +1,26 @@
+"""LLM provider implementations."""
+
+from .base import LLMProvider
+from .deepseek import DeepSeekProvider
+from .volcengine import VolcEngineProvider
+from .vllm import VLLMProvider
+from .ollama import OllamaProvider
+from .bailian import BailianProvider
+
+PROVIDER_MAP = {
+    "deepseek": DeepSeekProvider,
+    "volcengine": VolcEngineProvider,
+    "vllm": VLLMProvider,
+    "ollama": OllamaProvider,
+    "bailian": BailianProvider,
+}
+
+__all__ = [
+    "LLMProvider",
+    "DeepSeekProvider",
+    "VolcEngineProvider",
+    "VLLMProvider",
+    "OllamaProvider",
+    "BailianProvider",
+    "PROVIDER_MAP",
+]

--- a/llm/providers/bailian.py
+++ b/llm/providers/bailian.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from .base import LLMProvider
+
+
+class BailianProvider(LLMProvider):
+    """Provider for Alibaba Cloud's 百炼 (Bailian) service."""
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def chat(self, prompt: str, **kwargs: Any) -> Any:
+        url = f"{self.base_url or 'https://dashscope.aliyuncs.com'}/api/v1/chat/completions"
+        payload = {"input": {"messages": [{"role": "user", "content": prompt}]}}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate_image(self, prompt: str, **kwargs: Any) -> bytes:
+        url = f"{self.base_url or 'https://dashscope.aliyuncs.com'}/api/v1/images/generations"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def generate_video(self, prompt: str, **kwargs: Any) -> bytes:
+        url = f"{self.base_url or 'https://dashscope.aliyuncs.com'}/api/v1/videos/generations"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def analyze_media(self, media: bytes, **kwargs: Any) -> Any:
+        url = f"{self.base_url or 'https://dashscope.aliyuncs.com'}/api/v1/media/analyze"
+        files = {"media": media}
+        resp = requests.post(url, files=files, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()

--- a/llm/providers/base.py
+++ b/llm/providers/base.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class LLMProvider(ABC):
+    """Abstract base class for language model providers."""
+
+    def __init__(self, api_key: str, base_url: str | None = None) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/") if base_url else ""
+
+    @abstractmethod
+    def chat(self, prompt: str, **kwargs: Any) -> Any:
+        """Return a chat completion for the given prompt."""
+
+    @abstractmethod
+    def generate_image(self, prompt: str, **kwargs: Any) -> Any:
+        """Return an image generated for the prompt."""
+
+    @abstractmethod
+    def generate_video(self, prompt: str, **kwargs: Any) -> Any:
+        """Return a video generated for the prompt."""
+
+    @abstractmethod
+    def analyze_media(self, media: bytes, **kwargs: Any) -> Any:
+        """Analyze the given media and return a description or metadata."""

--- a/llm/providers/deepseek.py
+++ b/llm/providers/deepseek.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from .base import LLMProvider
+
+
+class DeepSeekProvider(LLMProvider):
+    """Provider for the DeepSeek API."""
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def chat(self, prompt: str, **kwargs: Any) -> Any:
+        url = f"{self.base_url or 'https://api.deepseek.com'}/chat/completions"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate_image(self, prompt: str, **kwargs: Any) -> bytes:
+        url = f"{self.base_url or 'https://api.deepseek.com'}/images/generations"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def generate_video(self, prompt: str, **kwargs: Any) -> bytes:
+        url = f"{self.base_url or 'https://api.deepseek.com'}/videos/generations"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def analyze_media(self, media: bytes, **kwargs: Any) -> Any:
+        url = f"{self.base_url or 'https://api.deepseek.com'}/media/analyze"
+        files = {"media": media}
+        resp = requests.post(url, files=files, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()

--- a/llm/providers/ollama.py
+++ b/llm/providers/ollama.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from .base import LLMProvider
+
+
+class OllamaProvider(LLMProvider):
+    """Provider for the Ollama local inference server."""
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+
+    def chat(self, prompt: str, **kwargs: Any) -> Any:
+        base = self.base_url or "http://localhost:11434"
+        url = f"{base}/api/chat"
+        payload = {
+            "model": kwargs.get("model", "llama2"),
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        payload.update({k: v for k, v in kwargs.items() if k not in {"model"}})
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate_image(self, prompt: str, **kwargs: Any) -> bytes:
+        base = self.base_url or "http://localhost:11434"
+        url = f"{base}/api/images"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def generate_video(self, prompt: str, **kwargs: Any) -> bytes:
+        base = self.base_url or "http://localhost:11434"
+        url = f"{base}/api/videos"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def analyze_media(self, media: bytes, **kwargs: Any) -> Any:
+        base = self.base_url or "http://localhost:11434"
+        url = f"{base}/api/media/analyze"
+        files = {"media": media}
+        resp = requests.post(url, files=files, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()

--- a/llm/providers/vllm.py
+++ b/llm/providers/vllm.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from .base import LLMProvider
+
+
+class VLLMProvider(LLMProvider):
+    """Provider for a vLLM server."""
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        return headers
+
+    def chat(self, prompt: str, **kwargs: Any) -> Any:
+        url = f"{self.base_url or 'http://localhost:8000'}/v1/chat/completions"
+        payload = {"messages": [{"role": "user", "content": prompt}]}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate_image(self, prompt: str, **kwargs: Any) -> bytes:
+        url = f"{self.base_url or 'http://localhost:8000'}/v1/images/generations"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def generate_video(self, prompt: str, **kwargs: Any) -> bytes:
+        url = f"{self.base_url or 'http://localhost:8000'}/v1/videos/generations"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def analyze_media(self, media: bytes, **kwargs: Any) -> Any:
+        url = f"{self.base_url or 'http://localhost:8000'}/v1/media/analyze"
+        files = {"media": media}
+        resp = requests.post(url, files=files, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()

--- a/llm/providers/volcengine.py
+++ b/llm/providers/volcengine.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from .base import LLMProvider
+
+
+class VolcEngineProvider(LLMProvider):
+    """Provider for the Volcano Engine (VolcEngine) API."""
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def chat(self, prompt: str, **kwargs: Any) -> Any:
+        url = f"{self.base_url or 'https://api.volcengine.com'}/chat/completions"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate_image(self, prompt: str, **kwargs: Any) -> bytes:
+        url = f"{self.base_url or 'https://api.volcengine.com'}/images/generations"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def generate_video(self, prompt: str, **kwargs: Any) -> bytes:
+        url = f"{self.base_url or 'https://api.volcengine.com'}/videos/generations"
+        payload = {"prompt": prompt}
+        payload.update(kwargs)
+        resp = requests.post(url, json=payload, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.content
+
+    def analyze_media(self, media: bytes, **kwargs: Any) -> Any:
+        url = f"{self.base_url or 'https://api.volcengine.com'}/media/analyze"
+        files = {"media": media}
+        resp = requests.post(url, files=files, headers=self._headers(), timeout=kwargs.get("timeout", 30))
+        resp.raise_for_status()
+        return resp.json()


### PR DESCRIPTION
## Summary
- add base LLMProvider interface
- add provider implementations for DeepSeek, VolcEngine, vLLM, Ollama and Bailian
- register new providers in PROVIDER_MAP

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68939638c3788323950238a4ef7ec549