### PR TITLE
Add LLM provider CRUD views and routes

### DIFF
--- a/framework/settings.py
+++ b/framework/settings.py
@@ -43,7 +43,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'app'
+    'app',
+    'llm'
 ]
 
 MIDDLEWARE = [

--- a/framework/urls.py
+++ b/framework/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     # path('admin/', admin.site.urls),
     # path(r'app/', include('app.urls')),
     path(r'', include('app.urls')),
+    path('llm/', include('llm.urls')),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/llm/apps.py
+++ b/llm/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class LlmConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "llm"

--- a/llm/migrations/0001_initial.py
+++ b/llm/migrations/0001_initial.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='LLMProvider',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100, unique=True)),
+                ('base_url', models.URLField(blank=True)),
+                ('api_key', models.CharField(blank=True, max_length=255)),
+            ],
+        ),
+    ]

--- a/llm/models.py
+++ b/llm/models.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class LLMProvider(models.Model):
+    name = models.CharField(max_length=100, unique=True)
+    base_url = models.URLField(blank=True)
+    api_key = models.CharField(max_length=255, blank=True)
+
+    def __str__(self) -> str:
+        return self.name

--- a/llm/urls.py
+++ b/llm/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+from .views import provider
+
+app_name = "llm"
+
+urlpatterns = [
+    path("providers/", provider.list_providers, name="provider-list"),
+    path("providers/create/", provider.create_provider, name="provider-create"),
+    path("providers/<int:pk>/update/", provider.update_provider, name="provider-update"),
+    path("providers/<int:pk>/delete/", provider.delete_provider, name="provider-delete"),
+]

--- a/llm/views/provider.py
+++ b/llm/views/provider.py
@@ -1,0 +1,58 @@
+import json
+from django.http import JsonResponse, HttpResponseNotAllowed
+from django.views.decorators.csrf import csrf_exempt
+from django.shortcuts import get_object_or_404
+from ..models import LLMProvider
+
+
+@csrf_exempt
+def list_providers(request):
+    if request.method != "GET":
+        return HttpResponseNotAllowed(["GET"])
+    providers = list(LLMProvider.objects.values())
+    return JsonResponse({"providers": providers})
+
+
+@csrf_exempt
+def create_provider(request):
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
+    data = json.loads(request.body.decode("utf-8") or "{}")
+    provider = LLMProvider.objects.create(
+        name=data.get("name", ""),
+        base_url=data.get("base_url", ""),
+        api_key=data.get("api_key", ""),
+    )
+    return JsonResponse({
+        "id": provider.id,
+        "name": provider.name,
+        "base_url": provider.base_url,
+        "api_key": provider.api_key,
+    })
+
+
+@csrf_exempt
+def update_provider(request, pk: int):
+    if request.method not in ["PUT", "PATCH"]:
+        return HttpResponseNotAllowed(["PUT", "PATCH"])
+    provider = get_object_or_404(LLMProvider, pk=pk)
+    data = json.loads(request.body.decode("utf-8") or "{}")
+    for field in ["name", "base_url", "api_key"]:
+        if field in data:
+            setattr(provider, field, data[field])
+    provider.save()
+    return JsonResponse({
+        "id": provider.id,
+        "name": provider.name,
+        "base_url": provider.base_url,
+        "api_key": provider.api_key,
+    })
+
+
+@csrf_exempt
+def delete_provider(request, pk: int):
+    if request.method != "DELETE":
+        return HttpResponseNotAllowed(["DELETE"])
+    provider = get_object_or_404(LLMProvider, pk=pk)
+    provider.delete()
+    return JsonResponse({"status": "deleted"})


### PR DESCRIPTION
## Summary
- add `LLMProvider` model with initial migration
- implement CRUD views for providers
- expose provider routes and register app

## Testing
- `python manage.py makemigrations llm` *(fails: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.0.4 (proxy 403))*
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_689396f6e66483238158c127dd048352