### PR TITLE
Add LLM endpoints and provider management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .ac
 app/utils/XcEncryCode.py
 manage.spec
-docs/*
 venv*
 __pycache__
 app/__pycache__

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,22 @@
+# API Documentation
+
+## LLM Endpoints
+| Method | Path | Description | Parameters |
+|--------|------|-------------|------------|
+| POST | `/api/llm/chat` | Text chat completion | `provider_id`, `model`, `messages` |
+| POST | `/api/llm/image` | Generate image | `provider_id`, `model`, `prompt`, `size` |
+| POST | `/api/llm/video` | Generate video | `provider_id`, `model`, `prompt`, `duration` |
+| POST | `/api/llm/analyze` | Analyze uploaded media | `provider_id`, `model`, `task`, `file` |
+
+All endpoints return JSON with `code` and `data`/`msg` fields. A `code` of `1000` indicates success.
+
+## Provider Management
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/llm/providers` | List configured providers |
+| POST | `/api/llm/providers/create` | Create provider |
+| PUT/PATCH | `/api/llm/providers/<id>/update` | Update provider |
+| DELETE | `/api/llm/providers/<id>/delete` | Delete provider |
+
+Provider fields: `name`, `type`, `base_url`, `api_key`, `is_active`, `extra`.
+

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,7 @@
+# Development Notes
+
+- Added provider factory with `get_provider` helper.
+- Implemented endpoints for image generation, video generation and media analysis.
+- Extended provider CRUD to handle `type`, `is_active` and `extra` fields.
+- Registered provider management URLs.
+

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,14 @@
+# Feature Verification
+
+This document summarizes the implementation status of features outlined in `DESIGN.md`.
+
+## Implemented
+- Unified provider factory with support for OpenAI, DeepSeek, VolcEngine, VLLM, Ollama and Bailian providers.
+- REST endpoints for text chat, image generation, video generation and media analysis under `/api/llm/`.
+- CRUD APIs for provider configuration.
+
+## Not Implemented / Pending
+- Agent system (chat/workflow).
+- Automatic labeling module.
+- Frontend rewrite with Vue3.
+

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,9 @@
+# Testing
+
+The project uses Django's test framework.
+
+```bash
+python manage.py test
+```
+
+**Note:** Dependency installation failed in the current environment, so tests could not be executed.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,8 @@
+# User Guide
+
+1. Configure providers via the `/api/llm/providers` endpoints.
+2. Use `/api/llm/chat` to send chat messages to a selected provider and model.
+3. `/api/llm/image` and `/api/llm/video` accept prompts to generate media.
+4. `/api/llm/analyze` accepts a file upload and returns analysis results.
+
+All requests require a `provider_id` referencing a configured provider.

--- a/llm/providers/__init__.py
+++ b/llm/providers/__init__.py
@@ -1,4 +1,4 @@
-"""LLM provider implementations."""
+"""LLM provider implementations and factory utilities."""
 
 from .base import LLMProvider
 from .deepseek import DeepSeekProvider
@@ -6,14 +6,40 @@ from .volcengine import VolcEngineProvider
 from .vllm import VLLMProvider
 from .ollama import OllamaProvider
 from .bailian import BailianProvider
+from .openai import OpenAIProvider
 
 PROVIDER_MAP = {
+    "openai": OpenAIProvider,
     "deepseek": DeepSeekProvider,
     "volcengine": VolcEngineProvider,
     "vllm": VLLMProvider,
     "ollama": OllamaProvider,
     "bailian": BailianProvider,
 }
+
+
+def get_provider(name: str, **kwargs) -> LLMProvider:
+    """Return an instance of the provider implementation.
+
+    Parameters
+    ----------
+    name: str
+        Provider type, e.g. ``openai`` or ``deepseek``.
+    **kwargs:
+        Keyword arguments passed to the provider constructor such as
+        ``api_key`` or ``base_url``.
+
+    Raises
+    ------
+    ValueError
+        If the provider name is unknown.
+    """
+
+    cls = PROVIDER_MAP.get(name.lower())
+    if not cls:
+        raise ValueError(f"Unknown provider: {name}")
+    return cls(**kwargs)
+
 
 __all__ = [
     "LLMProvider",
@@ -22,5 +48,7 @@ __all__ = [
     "VLLMProvider",
     "OllamaProvider",
     "BailianProvider",
+    "OpenAIProvider",
     "PROVIDER_MAP",
+    "get_provider",
 ]

--- a/llm/urls.py
+++ b/llm/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import LlmView
+from .views import LlmView, provider as provider_views
 
 app_name = 'llm'
 
@@ -9,4 +9,8 @@ urlpatterns = [
     path('image', LlmView.api_image),
     path('video', LlmView.api_video),
     path('analyze', LlmView.api_analyze),
+    path('providers', provider_views.list_providers),
+    path('providers/create', provider_views.create_provider),
+    path('providers/<int:pk>/update', provider_views.update_provider),
+    path('providers/<int:pk>/delete', provider_views.delete_provider),
 ]

--- a/llm/views/LlmView.py
+++ b/llm/views/LlmView.py
@@ -25,14 +25,59 @@ def api_chat(request):
 
 @csrf_exempt
 def api_image(request):
-    return HttpResponseJson({'code': 0, 'msg': 'not implemented'})
+    if request.method != 'POST':
+        return HttpResponseJson({'code': 0, 'msg': 'only POST allowed'})
+    params = parse_post_params(request)
+    provider_id = params.get('provider_id')
+    model = params.get('model')
+    prompt = params.get('prompt')
+    size = params.get('size')
+    try:
+        provider = LLMProvider.objects.filter(id=provider_id, is_active=True).first()
+        if not provider:
+            raise Exception('provider not found')
+        impl = get_provider(provider.type, base_url=provider.base_url, api_key=provider.api_key)
+        data = impl.generate_image(prompt=prompt, model=model, size=size)
+        return HttpResponseJson({'code': 1000, 'data': data})
+    except Exception as e:
+        return HttpResponseJson({'code': 0, 'msg': str(e)})
 
 
 @csrf_exempt
 def api_video(request):
-    return HttpResponseJson({'code': 0, 'msg': 'not implemented'})
+    if request.method != 'POST':
+        return HttpResponseJson({'code': 0, 'msg': 'only POST allowed'})
+    params = parse_post_params(request)
+    provider_id = params.get('provider_id')
+    model = params.get('model')
+    prompt = params.get('prompt')
+    duration = params.get('duration')
+    try:
+        provider = LLMProvider.objects.filter(id=provider_id, is_active=True).first()
+        if not provider:
+            raise Exception('provider not found')
+        impl = get_provider(provider.type, base_url=provider.base_url, api_key=provider.api_key)
+        data = impl.generate_video(prompt=prompt, model=model, duration=duration)
+        return HttpResponseJson({'code': 1000, 'data': data})
+    except Exception as e:
+        return HttpResponseJson({'code': 0, 'msg': str(e)})
 
 
 @csrf_exempt
 def api_analyze(request):
-    return HttpResponseJson({'code': 0, 'msg': 'not implemented'})
+    if request.method != 'POST':
+        return HttpResponseJson({'code': 0, 'msg': 'only POST allowed'})
+    params = parse_post_params(request)
+    provider_id = params.get('provider_id')
+    model = params.get('model')
+    task = params.get('task')
+    file_obj = request.FILES.get('file')
+    try:
+        provider = LLMProvider.objects.filter(id=provider_id, is_active=True).first()
+        if not provider:
+            raise Exception('provider not found')
+        impl = get_provider(provider.type, base_url=provider.base_url, api_key=provider.api_key)
+        data = impl.analyze_media(file_obj, task=task, model=model)
+        return HttpResponseJson({'code': 1000, 'data': data})
+    except Exception as e:
+        return HttpResponseJson({'code': 0, 'msg': str(e)})

--- a/llm/views/provider.py
+++ b/llm/views/provider.py
@@ -20,14 +20,20 @@ def create_provider(request):
     data = json.loads(request.body.decode("utf-8") or "{}")
     provider = LLMProvider.objects.create(
         name=data.get("name", ""),
+        type=data.get("type", ""),
         base_url=data.get("base_url", ""),
         api_key=data.get("api_key", ""),
+        is_active=data.get("is_active", True),
+        extra=json.dumps(data.get("extra", {})) if isinstance(data.get("extra"), (dict, list)) else data.get("extra", ""),
     )
     return JsonResponse({
         "id": provider.id,
         "name": provider.name,
+        "type": provider.type,
         "base_url": provider.base_url,
         "api_key": provider.api_key,
+        "is_active": provider.is_active,
+        "extra": provider.extra,
     })
 
 
@@ -37,15 +43,21 @@ def update_provider(request, pk: int):
         return HttpResponseNotAllowed(["PUT", "PATCH"])
     provider = get_object_or_404(LLMProvider, pk=pk)
     data = json.loads(request.body.decode("utf-8") or "{}")
-    for field in ["name", "base_url", "api_key"]:
+    for field in ["name", "type", "base_url", "api_key", "is_active", "extra"]:
         if field in data:
-            setattr(provider, field, data[field])
+            value = data[field]
+            if field == "extra" and isinstance(value, (dict, list)):
+                value = json.dumps(value)
+            setattr(provider, field, value)
     provider.save()
     return JsonResponse({
         "id": provider.id,
         "name": provider.name,
+        "type": provider.type,
         "base_url": provider.base_url,
         "api_key": provider.api_key,
+        "is_active": provider.is_active,
+        "extra": provider.extra,
     })
 
 


### PR DESCRIPTION
## Summary
- implement LLM provider factory with `get_provider`
- add chat, image, video and analysis endpoints
- expose CRUD APIs for provider configuration and add documentation

## Testing
- `python manage.py test llm` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6894e0bf699c832386cef35171b868a7