### PR TITLE
feat: add agent module and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 - 环境安装完成后，启动服务： python manage.py runserver 0.0.0.0:9924
 - 访问服务：在浏览器输入 http://127.0.0.1:9924 就可以开始了，默认账号 admin admin888
 
+### Agent API 示例
+- 创建 LLM Provider 和 Agent 后，可通过 `/api/agent/chat` 与 Agent 对话。
+- 执行简单工作流可调用 `/api/agent/workflow/execute`，请求体包含 `agent_id` 和 `workflow` 节点列表。
+
 ### 软件截图
 <img width="720" alt="5" src="https://gitee.com/Vanishi/images/raw/master/xclabel/5.png">
 <img width="720" alt="7" src="https://gitee.com/Vanishi/images/raw/master/xclabel/7.png">

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Agent application for managing conversational agents."""

--- a/agent/apps.py
+++ b/agent/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AgentConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'agent'

--- a/agent/migrations/0001_initial.py
+++ b/agent/migrations/0001_initial.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        ('llm', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Agent',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100)),
+                ('type', models.CharField(max_length=50)),
+                ('config', models.JSONField(blank=True, default=dict)),
+                ('provider', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='agents', to='llm.llmprovider')),
+            ],
+            options={'db_table': 'xc_agent'},
+        ),
+        migrations.CreateModel(
+            name='AgentSession',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('session_id', models.CharField(max_length=100, unique=True)),
+                ('messages', models.JSONField(blank=True, default=list)),
+                ('agent', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='sessions', to='agent.agent')),
+            ],
+            options={'db_table': 'xc_agent_session'},
+        ),
+        migrations.CreateModel(
+            name='WorkflowSession',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('session_id', models.CharField(max_length=100, unique=True)),
+                ('nodes', models.JSONField(blank=True, default=list)),
+                ('agent', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='workflows', to='agent.agent')),
+            ],
+            options={'db_table': 'xc_agent_workflow'},
+        ),
+    ]

--- a/agent/models.py
+++ b/agent/models.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from django.db import models
+from llm.models import LLMProvider
+
+
+class Agent(models.Model):
+    """Represents a configurable agent bound to an LLM provider."""
+
+    name = models.CharField(max_length=100)
+    type = models.CharField(max_length=50)
+    provider = models.ForeignKey(LLMProvider, on_delete=models.CASCADE, related_name='agents')
+    config = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        db_table = 'xc_agent'
+
+
+class AgentSession(models.Model):
+    """Stores conversation history for an agent instance."""
+
+    agent = models.ForeignKey(Agent, on_delete=models.CASCADE, related_name='sessions')
+    session_id = models.CharField(max_length=100, unique=True)
+    messages = models.JSONField(default=list, blank=True)
+
+    class Meta:
+        db_table = 'xc_agent_session'
+
+
+class WorkflowSession(models.Model):
+    """Tracks workflow execution nodes and their results."""
+
+    agent = models.ForeignKey(Agent, on_delete=models.CASCADE, related_name='workflows')
+    session_id = models.CharField(max_length=100, unique=True)
+    nodes = models.JSONField(default=list, blank=True)
+
+    class Meta:
+        db_table = 'xc_agent_workflow'

--- a/agent/tests.py
+++ b/agent/tests.py
@@ -1,0 +1,39 @@
+import json
+
+from django.test import TestCase, Client
+
+from llm.models import LLMProvider
+from .models import Agent
+
+
+class AgentAPITests(TestCase):
+    def setUp(self):
+        self.provider = LLMProvider.objects.create(
+            name='OpenAI', type='openai', api_key='test'
+        )
+        self.agent = Agent.objects.create(
+            name='bot', type='chat', provider=self.provider, config={'model': 'gpt-3.5-turbo'}
+        )
+        self.client = Client()
+
+    def test_chat_endpoint(self):
+        resp = self.client.post(
+            '/api/agent/chat',
+            data=json.dumps({'agent_id': self.agent.id, 'message': 'hi'}),
+            content_type='application/json'
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn('reply', data)
+        self.assertEqual(len(data['messages']), 2)
+
+    def test_workflow_execute(self):
+        workflow = [{'id': 'step1', 'prompt': 'hello'}]
+        resp = self.client.post(
+            '/api/agent/workflow/execute',
+            data=json.dumps({'agent_id': self.agent.id, 'workflow': workflow}),
+            content_type='application/json'
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data['nodes']), 1)

--- a/agent/urls.py
+++ b/agent/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from . import views
+
+app_name = 'agent'
+
+urlpatterns = [
+    path('chat', views.chat),
+    path('workflow/execute', views.execute_workflow),
+]

--- a/agent/views.py
+++ b/agent/views.py
@@ -1,0 +1,85 @@
+import json
+from uuid import uuid4
+
+from django.http import JsonResponse, HttpResponseNotAllowed
+from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_exempt
+
+from llm.providers import get_provider
+from .models import Agent, AgentSession, WorkflowSession
+
+
+@csrf_exempt
+def chat(request):
+    """Handle chat requests for a given agent."""
+
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
+
+    data = json.loads(request.body.decode("utf-8") or "{}")
+    agent_id = data.get("agent_id")
+    prompt = data.get("message", "")
+    session_id = data.get("session_id") or uuid4().hex
+
+    agent = get_object_or_404(Agent, pk=agent_id)
+    provider_impl = get_provider(
+        agent.provider.type,
+        api_key=agent.provider.api_key,
+        base_url=agent.provider.base_url,
+    )
+
+    session, _ = AgentSession.objects.get_or_create(agent=agent, session_id=session_id)
+    messages = session.messages
+    messages.append({"role": "user", "content": prompt})
+    result = provider_impl.chat(messages, model=agent.config.get("model"))
+    reply = result.get("reply") if isinstance(result, dict) else result
+    messages.append({"role": "assistant", "content": reply})
+    session.messages = messages
+    session.save()
+
+    return JsonResponse({
+        "session_id": session.session_id,
+        "reply": reply,
+        "messages": messages,
+    })
+
+
+@csrf_exempt
+def execute_workflow(request):
+    """Execute a simple sequential workflow for an agent."""
+
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
+
+    data = json.loads(request.body.decode("utf-8") or "{}")
+    agent_id = data.get("agent_id")
+    workflow_nodes = data.get("workflow", [])
+    session_id = data.get("session_id") or uuid4().hex
+
+    agent = get_object_or_404(Agent, pk=agent_id)
+    provider_impl = get_provider(
+        agent.provider.type,
+        api_key=agent.provider.api_key,
+        base_url=agent.provider.base_url,
+    )
+
+    session, _ = WorkflowSession.objects.get_or_create(agent=agent, session_id=session_id)
+    executed_nodes = session.nodes
+
+    for node in workflow_nodes:
+        prompt = node.get("prompt", "")
+        result = provider_impl.chat([{ "role": "user", "content": prompt }], model=agent.config.get("model"))
+        reply = result.get("reply") if isinstance(result, dict) else result
+        executed_nodes.append({
+            "id": node.get("id"),
+            "prompt": prompt,
+            "reply": reply,
+        })
+
+    session.nodes = executed_nodes
+    session.save()
+
+    return JsonResponse({
+        "session_id": session.session_id,
+        "nodes": executed_nodes,
+    })

--- a/framework/settings.py
+++ b/framework/settings.py
@@ -44,7 +44,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'app',
-    'llm'
+    'llm',
+    'agent',
 ]
 
 MIDDLEWARE = [

--- a/framework/urls.py
+++ b/framework/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     # path(r'app/', include('app.urls')),
     path(r'', include('app.urls')),
     path('api/llm/', include('llm.urls')),
+    path('api/agent/', include('agent.urls')),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/llm/providers/__init__.py
+++ b/llm/providers/__init__.py
@@ -6,6 +6,7 @@ from .volcengine import VolcEngineProvider
 from .vllm import VLLMProvider
 from .ollama import OllamaProvider
 from .bailian import BailianProvider
+from .openai import OpenAIProvider
 
 PROVIDER_MAP = {
     "deepseek": DeepSeekProvider,
@@ -13,6 +14,7 @@ PROVIDER_MAP = {
     "vllm": VLLMProvider,
     "ollama": OllamaProvider,
     "bailian": BailianProvider,
+    "openai": OpenAIProvider,
 }
 
 __all__ = [
@@ -22,5 +24,29 @@ __all__ = [
     "VLLMProvider",
     "OllamaProvider",
     "BailianProvider",
+    "OpenAIProvider",
     "PROVIDER_MAP",
+    "get_provider",
 ]
+
+
+def get_provider(provider_type: str, **kwargs) -> LLMProvider:
+    """Return an initialized provider implementation.
+
+    Args:
+        provider_type: The identifier for the provider implementation.
+        **kwargs: Additional keyword arguments passed to the provider constructor
+            such as ``api_key`` or ``base_url``.
+
+    Raises:
+        ValueError: If ``provider_type`` is not a supported provider.
+
+    Returns:
+        An instance of :class:`LLMProvider`.
+    """
+
+    try:
+        provider_cls = PROVIDER_MAP[provider_type]
+    except KeyError as exc:
+        raise ValueError(f"Unknown provider type: {provider_type}") from exc
+    return provider_cls(**kwargs)


### PR DESCRIPTION
## Summary
- add Agent models for chat sessions and workflow tracking
- expose `/api/agent/chat` and `/api/agent/workflow/execute` using provider factory
- document Agent API and include basic unit tests

## Testing
- `pip install django==5.0.4` *(fails: Could not find a version that satisfies the requirement django==5.0.4)*
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6894e420223483239ec8943c85c4e4a5