### PR TITLE
feat: add vue3 frontend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__
 app/__pycache__
 framework/__pycache__
 static/storage
+app/frontend/node_modules
+app/frontend/dist
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@
 - 环境安装完成后，启动服务： python manage.py runserver 0.0.0.0:9924
 - 访问服务：在浏览器输入 http://127.0.0.1:9924 就可以开始了，默认账号 admin admin888
 
+### 前端开发
+- 进入前端目录 `cd app/frontend`
+- 安装依赖 `npm install`
+- 开发调试 `npm run dev`
+- 运行测试 `npm test`
+- 构建产物 `npm run build`
+
 ### 软件截图
 <img width="720" alt="5" src="https://gitee.com/Vanishi/images/raw/master/xclabel/5.png">
 <img width="720" alt="7" src="https://gitee.com/Vanishi/images/raw/master/xclabel/7.png">

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>xclabel Frontend</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "xclabel-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "element-plus": "^2.6.5",
+    "vue": "^3.3.4",
+    "vue-router": "^4.2.5"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^4.2.3",
+    "vitest": "^0.34.5",
+    "vite": "^4.5.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -1,0 +1,10 @@
+<template>
+  <router-view />
+</template>
+
+<script setup>
+</script>
+
+<style>
+body { margin: 0; }
+</style>

--- a/app/frontend/src/__tests__/basic.test.js
+++ b/app/frontend/src/__tests__/basic.test.js
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('basic', () => {
+  it('adds numbers', () => {
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/app/frontend/src/api/index.js
+++ b/app/frontend/src/api/index.js
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: '/api',
+  withCredentials: true
+})
+
+export default api

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -1,0 +1,10 @@
+import { createApp } from 'vue'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
+import App from './App.vue'
+import router from './router'
+
+const app = createApp(App)
+app.use(ElementPlus)
+app.use(router)
+app.mount('#app')

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -1,0 +1,24 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import Login from '../views/Login.vue'
+import UserManagement from '../views/UserManagement.vue'
+import Tasks from '../views/Tasks.vue'
+import Samples from '../views/Samples.vue'
+import Labels from '../views/Labels.vue'
+import ModelInference from '../views/ModelInference.vue'
+import AgentConfig from '../views/AgentConfig.vue'
+
+const routes = [
+  { path: '/', redirect: '/login' },
+  { path: '/login', component: Login },
+  { path: '/users', component: UserManagement },
+  { path: '/tasks', component: Tasks },
+  { path: '/samples', component: Samples },
+  { path: '/labels', component: Labels },
+  { path: '/inference', component: ModelInference },
+  { path: '/agent', component: AgentConfig }
+]
+
+export default createRouter({
+  history: createWebHistory(),
+  routes
+})

--- a/app/frontend/src/views/AgentConfig.vue
+++ b/app/frontend/src/views/AgentConfig.vue
@@ -1,0 +1,19 @@
+<template>
+  <el-form :model="form" @submit.prevent="submit">
+    <el-form-item label="Name">
+      <el-input v-model="form.name" />
+    </el-form-item>
+    <el-form-item>
+      <el-button type="primary" native-type="submit">Save</el-button>
+    </el-form-item>
+  </el-form>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+import api from '../api'
+const form = reactive({ name: '' })
+const submit = async () => {
+  await api.post('/agent/', form)
+}
+</script>

--- a/app/frontend/src/views/Labels.vue
+++ b/app/frontend/src/views/Labels.vue
@@ -1,0 +1,15 @@
+<template>
+  <el-table :data="labels">
+    <el-table-column prop="name" label="Label" />
+  </el-table>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../api'
+const labels = ref([])
+onMounted(async () => {
+  const res = await api.get('/labels/')
+  labels.value = res.data
+})
+</script>

--- a/app/frontend/src/views/Login.vue
+++ b/app/frontend/src/views/Login.vue
@@ -1,0 +1,26 @@
+<template>
+  <el-form :model="form" class="login-form" @submit.prevent="submit">
+    <el-form-item label="Username">
+      <el-input v-model="form.username" />
+    </el-form-item>
+    <el-form-item label="Password">
+      <el-input type="password" v-model="form.password" />
+    </el-form-item>
+    <el-form-item>
+      <el-button type="primary" native-type="submit">Login</el-button>
+    </el-form-item>
+  </el-form>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+import api from '../api'
+const form = reactive({ username: '', password: '' })
+const submit = async () => {
+  await api.post('/login/', form)
+}
+</script>
+
+<style scoped>
+.login-form { max-width: 300px; margin: 100px auto; }
+</style>

--- a/app/frontend/src/views/ModelInference.vue
+++ b/app/frontend/src/views/ModelInference.vue
@@ -1,0 +1,22 @@
+<template>
+  <el-form :model="form" @submit.prevent="submit">
+    <el-form-item label="Input">
+      <el-input v-model="form.input" />
+    </el-form-item>
+    <el-form-item>
+      <el-button type="primary" native-type="submit">Run</el-button>
+    </el-form-item>
+  </el-form>
+  <div v-if="result">Result: {{ result }}</div>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue'
+import api from '../api'
+const form = reactive({ input: '' })
+const result = ref('')
+const submit = async () => {
+  const res = await api.post('/inference/', form)
+  result.value = res.data.result
+}
+</script>

--- a/app/frontend/src/views/Samples.vue
+++ b/app/frontend/src/views/Samples.vue
@@ -1,0 +1,15 @@
+<template>
+  <el-table :data="samples">
+    <el-table-column prop="id" label="ID" />
+  </el-table>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../api'
+const samples = ref([])
+onMounted(async () => {
+  const res = await api.get('/samples/')
+  samples.value = res.data
+})
+</script>

--- a/app/frontend/src/views/Tasks.vue
+++ b/app/frontend/src/views/Tasks.vue
@@ -1,0 +1,15 @@
+<template>
+  <el-table :data="tasks">
+    <el-table-column prop="name" label="Task" />
+  </el-table>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../api'
+const tasks = ref([])
+onMounted(async () => {
+  const res = await api.get('/tasks/')
+  tasks.value = res.data
+})
+</script>

--- a/app/frontend/src/views/UserManagement.vue
+++ b/app/frontend/src/views/UserManagement.vue
@@ -1,0 +1,16 @@
+<template>
+  <el-table :data="users">
+    <el-table-column prop="username" label="Username" />
+    <el-table-column prop="email" label="Email" />
+  </el-table>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../api'
+const users = ref([])
+onMounted(async () => {
+  const res = await api.get('/users/')
+  users.value = res.data
+})
+</script>

--- a/app/frontend/vite.config.js
+++ b/app/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add Vue 3 + Vite frontend scaffold with Element Plus and routing
- implement placeholder pages for login, user management, tasks, samples, labels, model inference, and agent config using axios
- document frontend development workflow in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-vue)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e42226948323aad28117b0ad5d5c